### PR TITLE
fixes #2 build failure for carbon-ir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,8 @@
+if [ ! -d "build" ] 
+then
+    mkdir build
+fi
+
 cd build
 
 cmake .. -DEXEC:BOOL=true

--- a/buildlib.sh
+++ b/buildlib.sh
@@ -1,3 +1,8 @@
+if [ ! -d "build" ] 
+then
+    mkdir build
+fi
+
 cd build
 
 cmake .. -DEXEC:BOOL=false


### PR DESCRIPTION
createt a build folder if not exist in a shell script